### PR TITLE
use http host instead of server name

### DIFF
--- a/lib/Clickalicious/PhpMemAdmin/App.php
+++ b/lib/Clickalicious/PhpMemAdmin/App.php
@@ -2195,10 +2195,10 @@ class App
         $pageUrl .= '://' . $prefix;
 
         if ($_SERVER['SERVER_PORT'] !== '80') {
-            $pageUrl .= $_SERVER['SERVER_NAME'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['PHP_SELF'];
+            $pageUrl .= $_SERVER['HTTP_HOST'] . ':' . $_SERVER['SERVER_PORT'] . $_SERVER['PHP_SELF'];
 
         } else {
-            $pageUrl .= $_SERVER['SERVER_NAME'] . $_SERVER['PHP_SELF'];
+            $pageUrl .= $_SERVER['HTTP_HOST'] . $_SERVER['PHP_SELF'];
 
         }
 


### PR DESCRIPTION
*$_SERVER['HTTP_HOST']* is more useful instead of *$_SERVER['SERVER_NAME']* as most of the installation does not configure server_name property and uses the default configuration.